### PR TITLE
Tell the user that it was mmap that failed in the second perror call

### DIFF
--- a/benchmark.c
+++ b/benchmark.c
@@ -71,7 +71,7 @@ jit_compile(struct jit_func *f, void (*empty)(void))
     size_t len = PAGESIZE * 2;
     unsigned char *p = mmap(desired, len, prot, MAP_PRIVATE, zero, 0);
     if (p == MAP_FAILED) {
-        perror("/dev/zero");
+        perror("mmap");
         exit(EXIT_FAILURE);
     }
     close(zero);


### PR DESCRIPTION
It looks a copy and paste error, but not sure though. Still, here's a small PR if you didn't intend to write "/dev/zero" in the second check :-)